### PR TITLE
Updates from 02/04/21 talk

### DIFF
--- a/config/static-assets/static/regulations/css/scss/_mixins.scss
+++ b/config/static-assets/static/regulations/css/scss/_mixins.scss
@@ -16,7 +16,6 @@ mixins.scss contains complex mixins to be used throughout the Sass files
 @mixin regulation-nav-section-marker-font {
   @include sans-font-bold;
   display: block;
-  font-size: 16px;
 }
 
 @mixin regulation-nav-interp-heading-font {

--- a/config/static-assets/static/regulations/css/scss/partials/_drawer-content.scss
+++ b/config/static-assets/static/regulations/css/scss/partials/_drawer-content.scss
@@ -24,7 +24,7 @@ This contains all of the styles specific to the TOC
     a:hover,
     a:active,
     .current {
-      padding-left: 102px;
+      padding-left: 100px;
       margin-left: -100px;
     }
 
@@ -86,9 +86,21 @@ This contains all of the styles specific to the TOC
       cursor: pointer;
     }
 
+    &.section-subpart:hover {
+      background: #046791;
+
+      h3 {
+        background: #046791;
+      }
+    }
+
     &:not([data-subpart-heading]) {
       padding: 0 1em 0 20px;
       font-size: 14px;
+      &.section-subjgrp {
+        padding: 0 1rem;
+	color: white;
+      }
     }
   }
 
@@ -131,10 +143,10 @@ This contains all of the styles specific to the TOC
 
   a {
     display: block;
-    // padding: 7px 15px 8px 102px;
-    padding: 7px 15px 8px 82px;
-    margin-left: -100px;
+    padding-top: 7px;
+    padding-bottom: 8px;
     line-height: 1.3;
+    padding-right: 10px;
   }
 
   a:link,
@@ -145,7 +157,7 @@ This contains all of the styles specific to the TOC
   a:hover,
   a:active {
     margin-left: -100px;
-    padding-left: 102px;
+    padding-left: 100px;
     color: $white;
     background-color: $medicare_blue_less_dark;
   }
@@ -204,8 +216,8 @@ This contains all of the styles specific to the TOC
   background-color: $panel_background_color;
   font-size: 1em;
   color: $medicare_blue_light;
-  &:hover {
-    cursor: pointer;
+  &.toc-subjgrp:hover {
+    cursor: default;
   }
 }
 
@@ -229,6 +241,7 @@ This contains all of the styles specific to the TOC
   @include sans-font-regular;
   display: block;
   color: $white;
+  width: 90%;
 }
 
 /*

--- a/guidance/content/regulations/toc-subpart.html
+++ b/guidance/content/regulations/toc-subpart.html
@@ -1,5 +1,5 @@
 <li data-subpart-heading data-subgroup="subpart-{{item.index|last}}" id="{{item}}" class="subpart-heading-{{item.index|last}} section-subpart" tabindex="0">
-  <h3 class="toc-nav__divider " data-section-id="{{item.section_id}}" id="nav-{{item.section_id}}">{{item.label|safe|upper}} - 
+  <h3 class="toc-nav__divider " data-section-id="{{item.section_id}}" id="nav-{{item.section_id}}">{{item.label|safe}} 
     <span class="toggle-button-open" aria-hidden="false"><i class="fa fa-chevron-down"></i></span>
     <span class="toggle-button-close" aria-hidden="true"><i class="fa fa-chevron-up"></i></span>
     <span class="subpart-subhead">{{item.sub_label|safe}}</span>


### PR DESCRIPTION
- prevent sections from moving on hover
- hover background state for subparts
- reduce indent for sections and subgroups
- remove hand cursor for subgroups
- stop upper casing subparts